### PR TITLE
Bunch of optimizations / flag / config tweaking for speed

### DIFF
--- a/src/core/bvh.oc
+++ b/src/core/bvh.oc
@@ -1,6 +1,8 @@
 import std::vector::Vector
 import std::vec::Vec3f
 import std::sort::{ nth_element_by, partition_by_closure }  // def nth_element_by(data: &T, size: u32, n: u32, cmp: <unknown>): T
+import std::time::get_time_monotonic_ms
+import std::logging::{ log }
 import @core::object::Object
 import @core::bounds::Bounds
 import @core::ray::Ray
@@ -106,7 +108,7 @@ def BVH::split_SAH(objects: &Vector<T>, start: u32, end: u32, bounds: Bounds, ax
 }
 
 
-def BVH::create(objects: &Vector<T>, start: u32, end: u32): &BVH<T> {
+def BVH::create_rec(objects: &Vector<T>, start: u32, end: u32): &BVH<T> {
     if end - start == 1 {
         let object = objects[start]
         let bounds = object.bounds()
@@ -128,8 +130,8 @@ def BVH::create(objects: &Vector<T>, start: u32, end: u32): &BVH<T> {
 
         let mid = BVH<T>::split_SAH(objects, start, end, bounds, dim)
 
-        let l = BVH<T>::create(objects, start, mid)
-        let r = BVH<T>::create(objects, mid, end)
+        let l = BVH<T>::create_rec(objects, start, mid)
+        let r = BVH<T>::create_rec(objects, mid, end)
 
         let internal: BVH<T>
         internal.is_leaf = false
@@ -139,6 +141,14 @@ def BVH::create(objects: &Vector<T>, start: u32, end: u32): &BVH<T> {
 
         return @new internal
     }
+}
+
+def BVH::create(objects: &Vector<T>): &BVH<T> {
+    let start_time = get_time_monotonic_ms()
+    let bvh = BVH<T>::create_rec(objects, 0, objects.size)
+    let duration = get_time_monotonic_ms() - start_time
+    log(Info, f"BVH created with {objects.size} objects in {duration/1000.0:.2f}s")
+    return bvh
 }
 
 

--- a/src/main.oc
+++ b/src/main.oc
@@ -8,6 +8,8 @@ import std::video_renderer::VideoRenderer
 import std::gc
 import std::json::parse_from_file
 import std::argparse::Parser
+import std::logging::{ init_logging, log }
+import std::time::get_time_monotonic_ms
 import @core::camera::Camera
 import @core::matrix::Matrix
 import @core::scene::Scene
@@ -21,17 +23,26 @@ import @core::bvh::BVH
 
 
 def main(argc: i32, argv: &str) {
+    init_logging()
+
     let parser = Parser::make("ocen-raytracer")
     let scene_path = parser.add_str("scene", help:"Path to the scene JSON file")
     let out_file = parser.add_str("-o", help:"Path to the output image file", defolt:"./build/out.png")
     parser.parse(argc, argv)
+
+    log(Info, f"Loading scene from {*scene_path}")
     let scene = Scene::from_json(parse_from_file(*scene_path))
+    log(Info, f"Scene loaded with {scene.objects.size} objects")
+
+    log(Info, f"Rendering {scene.camera.width}x{scene.camera.height} image with {scene.camera.num_samples} samples per pixel")
     let image = Image::new(scene.camera.width, scene.camera.height)
     render(image, &scene)
+    log(Info, f"Saving image to {*out_file}")
     image.save(*out_file)
 }
 
 def render(img: &Image, scene: &Scene) {
+    let start = get_time_monotonic_ms()
     let completed = 0
 
     OMP_PARALLEL_FOR
@@ -48,6 +59,9 @@ def render(img: &Image, scene: &Scene) {
         completed += 1
         print(f"\r  {completed}/{img.height}")
     }
+    println("")
+    let duration = get_time_monotonic_ms() - start
+    log(Info, f"Rendering completed in {duration/1000.0:.2f}s")
 }
 
 def std::image::Color::from_vec(vec: Vec3f): Color {

--- a/src/objects/mesh.oc
+++ b/src/objects/mesh.oc
@@ -68,7 +68,7 @@ def Mesh::from_obj(filename: str): Mesh {
             else => {}
         }
     }
-    let bvh = BVH<Triangle>::create(triangles, 0, triangles.size)
+    let bvh = BVH<Triangle>::create(triangles)
     return Mesh(triangles, bvh)
 }
 


### PR DESCRIPTION
Read commit descriptions. Overall improvement for `dragon.json` and 1080p 25 samples:

Before: `390.01s user 0.98s system 605% cpu 1:04.55 total`

After: `66.20s user 0.18s system 928% cpu 7.148 total`

~9x speed improvement.

## Summary by Sourcery

Apply a series of algorithmic and configuration optimizations—including BVH improvements, parallelism, and CLI flags—to achieve roughly 9× speedup in rendering performance.

Enhancements:
- Optimize BVH construction and traversal for faster scene processing
- Parallelize rendering with configurable threading options
- Introduce command-line flags and config tweaks for performance tuning
- Adjust default configuration values to improve common workloads